### PR TITLE
PA-23889 inskinesis Package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,19 +5,20 @@ go 1.19
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Jamil-Najafov/go-aws-ssm v0.9.0
+	github.com/aws/aws-sdk-go v1.44.3
 	github.com/getsentry/sentry-go v0.13.0
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/golang/mock v1.6.0
+	github.com/google/uuid v1.3.1
 	github.com/jellydator/ttlcache/v3 v3.0.0
-	github.com/pkg/errors v0.9.1
 	github.com/slok/goresilience v0.2.0
 	github.com/stretchr/testify v1.7.0
+	go.uber.org/mock v0.3.0
 	gorm.io/driver/mysql v1.3.4
 	gorm.io/gorm v1.23.7
 )
 
 require (
-	github.com/aws/aws-sdk-go v1.44.3 // indirect
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
@@ -34,6 +35,7 @@ require (
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 // indirect
 	github.com/prometheus/common v0.0.0-20181126121408-4724e9255275 // indirect
 	github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jellydator/ttlcache/v3 v3.0.0 h1:zmFhqrB/4sKiEiJHhtseJsNRE32IMVmJSs4++4gaQO4=
 github.com/jellydator/ttlcache/v3 v3.0.0/go.mod h1:WwTaEmcXQ3MTjOm4bsZoDFiCu/hMvNWLO1w67RXz6h4=
@@ -87,6 +89,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
+go.uber.org/mock v0.3.0 h1:3mUxI1No2/60yUYax92Pt8eNOEecx2D3lcXZh2NEZJo=
+go.uber.org/mock v0.3.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -102,6 +106,7 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -133,8 +138,8 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.1 h1:wGiQel/hW0NnEkJUk8lbzkX2gFJU6PFxf1v5OlCfuOs=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.2.0 h1:G6AHpWxTMGY1KyEYoAQ5WTtIekUUvDNjan3ugu60JvE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/inskinesis/README.md
+++ b/inskinesis/README.md
@@ -1,0 +1,144 @@
+# Kinesis Package
+
+The `inskinesis` package is a Go library designed to facilitate streaming data to Amazon Kinesis streams. This README provides an overview of the package's functionality and usage.
+
+## Table of Contents
+
+- [Introduction](#introduction)
+- [Installation](#installation)
+- [Getting Started](#getting-started)
+- [Package Structure](#package-structure)
+- [Usage](#usage)
+- [Error Handling](#error-handling)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Introduction
+
+The `inskinesis` package is designed to make it easier to stream data to Amazon Kinesis streams in your Go applications. It provides a simple interface for sending records to a Kinesis stream while handling batching, partitioning, and retries. This can be especially useful for applications that generate a high volume of data and need to send it to Kinesis efficiently.
+
+## Installation
+
+To use the `inskinesis` package in your Go project, you can install it using Go modules. Run the following command in your project directory:
+
+```bash
+go get github.com/go-pkg/inskinesis
+```
+
+## Getting Started
+
+Here's a quick guide on how to get started with the `inskinesis` package:
+
+1. Import the package in your Go code:
+
+   ```go
+   import "github.com/go-pkg/inskinesis"
+   ```
+
+2. Create a configuration for your Kinesis stream:
+
+   ```go
+   config := inskinesis.Config{
+       Region:                 "your-aws-region",
+       StreamName:             "your-kinesis-stream-name",
+       Partitioner:            nil, // Optionally provide a partitioner function
+       MaxStreamBatchSize:     100, // Maximum size of each batch of records
+       MaxStreamBatchByteSize: 1024 * 1024, // Maximum size in bytes for each batch
+       MaxBatchSize:           500, // Maximum size of the log buffer
+       MaxGroup:               10, // Maximum number of concurrent groups for sending records
+   }
+   ```
+
+3. Create a Kinesis stream instance:
+
+   ```go
+   stream, err := inskinesis.NewKinesis(config)
+   if err != nil {
+       // Handle the error
+   }
+   ```
+
+4. Send records to the Kinesis stream:
+
+   ```go
+   // Send a single record
+   stream.Put(yourRecord)
+
+   // Send multiple records
+   records := []interface{}{record1, record2, record3}
+   for _, record := range records {
+       stream.Put(record)
+   }
+   ```
+
+5. To ensure all records are sent and clean up resources, flush and stop streaming:
+
+   ```go
+   stream.FlushAndStopStreaming()
+   ```
+
+## Package Structure
+
+The `inskinesis` package is organized as follows:
+
+- `inskinesis` package: The main package containing the `StreamInterface`, `stream`, and related functionality for streaming records to Kinesis.
+- `PartitionerFunction`: A customizable partitioning function for determining the partition key of records.
+- `CreateBatches`: A utility function for creating batches of records.
+- Various error handling and logging functionality.
+
+## Usage
+
+The package provides a simple interface for streaming records to a Kinesis stream. You can customize the configuration based on your needs, including the region, stream name, batch sizes, and partitioning function.
+
+Here's an example of how to use the package:
+
+```go
+import "github.com/go-pkg/inskinesis"
+
+config := inskinesis.Config{
+    Region:                 "your-aws-region",
+    StreamName:             "your-kinesis-stream-name",
+    Partitioner:            nil, // Optionally provide a partitioner function
+    MaxStreamBatchSize:     100, // Maximum size of each batch of records
+    MaxStreamBatchByteSize: 1024 * 1024, // Maximum size in bytes for each batch
+    MaxBatchSize:           500, // Maximum size of the log buffer
+    MaxGroup:               10, // Maximum number of concurrent groups for sending records
+}
+
+stream, err := inskinesis.NewKinesis(config)
+if err != nil {
+    // Handle the error
+}
+
+// Send records to the stream
+stream.Put(yourRecord)
+
+// To ensure all records are sent and clean up resources, flush and stop streaming
+stream.FlushAndStopStreaming()
+```
+
+## Error Handling
+
+The `inskinesis` package provides error channels for receiving errors during streaming. You can use these channels to handle errors in your application gracefully. It's important to monitor the error channels to ensure the robustness of your data streaming process.
+
+Here's an example of how to use the error channels:
+
+```go
+go func() {
+   for {
+      select {
+      case err := <-stream.Error():
+        sentry.Error(err)
+      }
+   }
+}()
+
+```
+
+## Contributing
+
+If you would like to contribute to the `inskinesis` package, please follow standard Go community guidelines for contributions. You can create issues, submit pull requests, and help improve the package for everyone.
+
+## License
+
+This package is available under the MIT License. You can find the full license details in the LICENSE file included in the package. Make sure to review and comply with the license when using the package in your project.

--- a/inskinesis/README.md
+++ b/inskinesis/README.md
@@ -11,7 +11,6 @@ The `inskinesis` package is a Go library designed to facilitate streaming data t
 - [Usage](#usage)
 - [Error Handling](#error-handling)
 - [Contributing](#contributing)
-- [License](#license)
 
 ## Introduction
 
@@ -138,7 +137,3 @@ go func() {
 ## Contributing
 
 If you would like to contribute to the `inskinesis` package, please follow standard Go community guidelines for contributions. You can create issues, submit pull requests, and help improve the package for everyone.
-
-## License
-
-This package is available under the MIT License. You can find the full license details in the LICENSE file included in the package. Make sure to review and comply with the license when using the package in your project.

--- a/inskinesis/README.md
+++ b/inskinesis/README.md
@@ -27,7 +27,7 @@ To use the `inskinesis` package in your Go project, you can install it using Go 
 your project directory:
 
 ```bash
-go get github.com/go-pkg/inskinesis
+go get github.com/useinsider/go-pkg/inskinesis
 ```
 
 ## Getting Started
@@ -37,7 +37,7 @@ Here's a quick guide on how to get started with the `inskinesis` package:
 1. Import the package in your Go code:
 
    ```go
-   import "github.com/go-pkg/inskinesis"
+   import "github.com/useinsider/go-pkg/inskinesis"
    ```
 
 2. Create a configuration for your Kinesis stream:
@@ -114,16 +114,16 @@ based on your needs, including the region, stream name, batch sizes, and partiti
 Here's an example of how to use the package:
 
 ```go
-import "github.com/go-pkg/inskinesis"
+import "github.com/useinsider/go-pkg/inskinesis"
 
 config := inskinesis.Config{
-Region:                 "your-aws-region",
-StreamName:             "your-kinesis-stream-name",
-Partitioner:            nil, // Optionally provide a partitioner function
-MaxStreamBatchSize:     100, // Maximum size of each batch of records
-MaxStreamBatchByteSize: 1024 * 1024, // Maximum size in bytes for each batch
-MaxBatchSize:           500,         // Maximum size of the log buffer
-MaxGroup:               10, // Maximum number of concurrent groups for sending records
+    Region:                 "your-aws-region",
+    StreamName:             "your-kinesis-stream-name",
+    Partitioner:            nil, // Optionally provide a partitioner function
+    MaxStreamBatchSize:     100, // Maximum size of each batch of records
+    MaxStreamBatchByteSize: 1024 * 1024, // Maximum size in bytes for each batch
+    MaxBatchSize:           500,         // Maximum size of the log buffer
+    MaxGroup:               10, // Maximum number of concurrent groups for sending records
 }
 
 stream, err := inskinesis.NewKinesis(config)
@@ -148,12 +148,12 @@ Here's an example of how to use the error channels:
 
 ```go
 go func () {
-for {
-select {
-case err := <-stream.Error():
-sentry.Error(err)
-}
-}
+    for {
+        select {
+        case err := <-stream.Error():
+            sentry.Error(err)
+        }
+    }
 }()
 
 ```

--- a/inskinesis/README.md
+++ b/inskinesis/README.md
@@ -1,6 +1,7 @@
 # Kinesis Package
 
-The `inskinesis` package is a Go library designed to facilitate streaming data to Amazon Kinesis streams. This README provides an overview of the package's functionality and usage.
+The `inskinesis` package is a Go library designed to facilitate streaming data to Amazon Kinesis streams. This README
+provides an overview of the package's functionality and usage.
 
 ## Table of Contents
 
@@ -9,16 +10,21 @@ The `inskinesis` package is a Go library designed to facilitate streaming data t
 - [Getting Started](#getting-started)
 - [Package Structure](#package-structure)
 - [Usage](#usage)
-- [Error Handling](#error-handling)
-- [Contributing](#contributing)
+- [Error Handling](#error-handling)r
+- [Contributing](#contributing
+  )
 
 ## Introduction
 
-The `inskinesis` package is designed to make it easier to stream data to Amazon Kinesis streams in your Go applications. It provides a simple interface for sending records to a Kinesis stream while handling batching, partitioning, and retries. This can be especially useful for applications that generate a high volume of data and need to send it to Kinesis efficiently.
+The `inskinesis` package is designed to make it easier to stream data to Amazon Kinesis streams in your Go applications.
+It provides a simple interface for sending records to a Kinesis stream while handling batching, partitioning, and
+retries. This can be especially useful for applications that generate a high volume of data and need to send it to
+Kinesis efficiently.
 
 ## Installation
 
-To use the `inskinesis` package in your Go project, you can install it using Go modules. Run the following command in your project directory:
+To use the `inskinesis` package in your Go project, you can install it using Go modules. Run the following command in
+your project directory:
 
 ```bash
 go get github.com/go-pkg/inskinesis
@@ -47,6 +53,21 @@ Here's a quick guide on how to get started with the `inskinesis` package:
        MaxGroup:               10, // Maximum number of concurrent groups for sending records
    }
    ```
+
+| Field                  | Default Value      | Description                                                                                                                                       |
+|------------------------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| Region                 | N/A                | The AWS region where the Kinesis stream is located. **Required**                                                                                  |
+| StreamName             | N/A                | The name of the Kinesis stream. **Required**                                                                                                      |
+| Partitioner            | UUID               | An optional partitioner function used to determine the partition key for records. If not provided, a default UUID-based partitioner is used.      |
+| MaxStreamBatchSize     | 100                | The maximum size of each batch of records to be sent to the stream.                                                                               |
+| MaxStreamBatchByteSize | 256 KB (2^18 byte) | The maximum size (in bytes) of each batch of records.                                                                                             |
+| MaxBatchSize           | 500                | The maximum size of the log buffer for accumulating log records before batching.                                                                  |
+| MaxGroup               | 1                  | The maximum number of concurrent groups for sending records. If you want to send records concurrently, set this value to a number greater than 1. |
+| RetryCount             | 3                  | The number of times to retry sending a batch of records to the stream.                                                                            |
+| RetryInterval          | 100 ms             | The interval between retries.                                                                                                                     |
+
+Please note that `N/A` in the Default Value column indicates that these fields are required and do not have default
+values.
 
 3. Create a Kinesis stream instance:
 
@@ -80,14 +101,15 @@ Here's a quick guide on how to get started with the `inskinesis` package:
 
 The `inskinesis` package is organized as follows:
 
-- `inskinesis` package: The main package containing the `StreamInterface`, `stream`, and related functionality for streaming records to Kinesis.
+- `inskinesis` package: The main package containing the `StreamInterface`, `stream`, and related functionality for
+  streaming records to Kinesis.
 - `PartitionerFunction`: A customizable partitioning function for determining the partition key of records.
-- `CreateBatches`: A utility function for creating batches of records.
 - Various error handling and logging functionality.
 
 ## Usage
 
-The package provides a simple interface for streaming records to a Kinesis stream. You can customize the configuration based on your needs, including the region, stream name, batch sizes, and partitioning function.
+The package provides a simple interface for streaming records to a Kinesis stream. You can customize the configuration
+based on your needs, including the region, stream name, batch sizes, and partitioning function.
 
 Here's an example of how to use the package:
 
@@ -95,18 +117,18 @@ Here's an example of how to use the package:
 import "github.com/go-pkg/inskinesis"
 
 config := inskinesis.Config{
-    Region:                 "your-aws-region",
-    StreamName:             "your-kinesis-stream-name",
-    Partitioner:            nil, // Optionally provide a partitioner function
-    MaxStreamBatchSize:     100, // Maximum size of each batch of records
-    MaxStreamBatchByteSize: 1024 * 1024, // Maximum size in bytes for each batch
-    MaxBatchSize:           500, // Maximum size of the log buffer
-    MaxGroup:               10, // Maximum number of concurrent groups for sending records
+Region:                 "your-aws-region",
+StreamName:             "your-kinesis-stream-name",
+Partitioner:            nil, // Optionally provide a partitioner function
+MaxStreamBatchSize:     100, // Maximum size of each batch of records
+MaxStreamBatchByteSize: 1024 * 1024, // Maximum size in bytes for each batch
+MaxBatchSize:           500,         // Maximum size of the log buffer
+MaxGroup:               10, // Maximum number of concurrent groups for sending records
 }
 
 stream, err := inskinesis.NewKinesis(config)
 if err != nil {
-    // Handle the error
+// Handle the error
 }
 
 // Send records to the stream
@@ -118,22 +140,25 @@ stream.FlushAndStopStreaming()
 
 ## Error Handling
 
-The `inskinesis` package provides error channels for receiving errors during streaming. You can use these channels to handle errors in your application gracefully. It's important to monitor the error channels to ensure the robustness of your data streaming process.
+The `inskinesis` package provides error channels for receiving errors during streaming. You can use these channels to
+handle errors in your application gracefully. It's important to monitor the error channels to ensure the robustness of
+your data streaming process.
 
 Here's an example of how to use the error channels:
 
 ```go
-go func() {
-   for {
-      select {
-      case err := <-stream.Error():
-        sentry.Error(err)
-      }
-   }
+go func () {
+for {
+select {
+case err := <-stream.Error():
+sentry.Error(err)
+}
+}
 }()
 
 ```
 
 ## Contributing
 
-If you would like to contribute to the `inskinesis` package, please follow standard Go community guidelines for contributions. You can create issues, submit pull requests, and help improve the package for everyone.
+If you would like to contribute to the `inskinesis` package, please follow standard Go community guidelines for
+contributions. You can create issues, submit pull requests, and help improve the package for everyone.

--- a/inskinesis/helper.go
+++ b/inskinesis/helper.go
@@ -1,0 +1,25 @@
+package inskinesis
+
+import "reflect"
+
+func TakeSliceArg(arg interface{}) (out []interface{}, ok bool) {
+	slice, success := takeArg(arg, reflect.Slice)
+	if !success {
+		ok = false
+		return
+	}
+	c := slice.Len()
+	out = make([]interface{}, c)
+	for i := 0; i < c; i++ {
+		out[i] = slice.Index(i).Interface()
+	}
+	return out, true
+}
+
+func takeArg(arg interface{}, kind reflect.Kind) (val reflect.Value, ok bool) {
+	val = reflect.ValueOf(arg)
+	if val.Kind() == kind {
+		ok = true
+	}
+	return
+}

--- a/inskinesis/inskinesis.go
+++ b/inskinesis/inskinesis.go
@@ -200,7 +200,7 @@ func (s *stream) startBatchStreaming() {
 	for {
 		select {
 		case batch := <-s.batchChannel:
-			s.sendSingleBatch(concurrentLimiter, batch)
+			s.sendSingleBatch(batch, concurrentLimiter)
 		case <-s.stopBatchChannel:
 			go func() {
 				defer s.wgBatchChan.Done()
@@ -217,7 +217,7 @@ func (s *stream) startBatchStreaming() {
 				for _, b := range batches {
 					s.wgBatchChan.Add(1)
 					batch := b
-					s.sendSingleBatch(concurrentLimiter, batch)
+					s.sendSingleBatch(batch, concurrentLimiter)
 				}
 			}()
 
@@ -226,7 +226,7 @@ func (s *stream) startBatchStreaming() {
 	}
 }
 
-func (s *stream) sendSingleBatch(concurrentLimiter chan struct{}, batch []interface{}) {
+func (s *stream) sendSingleBatch(batch []interface{}, concurrentLimiter chan struct{}) {
 	concurrentLimiter <- struct{}{}
 	go func() {
 		defer func() {

--- a/inskinesis/inskinesis.go
+++ b/inskinesis/inskinesis.go
@@ -1,0 +1,393 @@
+package inskinesis
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kinesis"
+)
+
+const (
+	outputSeparator = byte('\n')
+	RetryCount      = 3
+	RetryWaitTime   = 100 * time.Millisecond
+)
+
+type KinesisInterface interface {
+	PutRecords(input *kinesis.PutRecordsInput) (*kinesis.PutRecordsOutput, error)
+}
+
+type kinesisProxy struct {
+	*kinesis.Kinesis
+}
+
+func (k *kinesisProxy) PutRecords(input *kinesis.PutRecordsInput) (*kinesis.PutRecordsOutput, error) {
+	return k.Kinesis.PutRecords(input)
+}
+
+// StreamInterface defines the interface for a Kinesis stream.
+type StreamInterface interface {
+	Put(record interface{})
+	Error() <-chan error
+	FlushAndStopStreaming()
+}
+
+// stream represents a Kinesis stream and its properties.
+type stream struct {
+	region        string               // AWS region where the Kinesis stream is located.
+	name          string               // Name of the Kinesis stream.
+	partitioner   *PartitionerFunction // The partitioning function used to determine the partition key for records.
+	kinesisClient KinesisInterface     // AWS Kinesis client for interacting with the stream.
+
+	logBufferSize          int // Maximum size of the log buffer for records.
+	maxStreamBatchSize     int // Maximum size of each batch of records to be sent to the stream.
+	maxStreamBatchByteSize int // Maximum size (in bytes) of each batch of records.
+	maxGroup               int // Maximum number of concurrent groups for sending records.
+
+	mu               sync.Mutex         // Mutex to synchronize access to the stream.
+	wgLogChan        *sync.WaitGroup    // WaitGroup to manage goroutines.
+	wgBatchChan      *sync.WaitGroup    // WaitGroup to manage goroutines.
+	logChannel       chan interface{}   // Channel for receiving individual log records.
+	batchChannel     chan []interface{} // Channel for sending batches of log records.
+	stopChannel      chan bool          // Channel to signal the termination of the streaming process.
+	errChannel       chan error         // Channel for receiving errors.
+	stopBatchChannel chan bool          // Channel to signal the termination of batch streaming.
+	logBuffer        []interface{}      // Buffer for accumulating log records before batching.
+
+	failedCount int // Counter for the number of failed record submissions.
+	totalCount  int // Counter for the total number of records sent to the stream.
+}
+
+type Config struct {
+	Region                 string
+	StreamName             string
+	Partitioner            *PartitionerFunction
+	MaxStreamBatchSize     int
+	MaxStreamBatchByteSize int
+	MaxBatchSize           int
+	MaxGroup               int
+}
+
+// NewKinesis creates a new Kinesis stream.
+func NewKinesis(config Config) (StreamInterface, error) {
+	if config.Region == "" {
+		return nil, errors.New("region is required")
+	}
+
+	if config.StreamName == "" {
+		return nil, errors.New("stream name is required")
+	}
+	awsConfig := aws.Config{Region: aws.String(config.Region)}
+	awsSession, err := session.NewSession(&awsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	kinesisClient := kinesis.New(awsSession)
+
+	s := &stream{
+		region:        config.Region,
+		name:          config.StreamName,
+		partitioner:   config.Partitioner,
+		kinesisClient: kinesisClient,
+
+		logBufferSize:          config.MaxBatchSize,
+		maxStreamBatchSize:     config.MaxStreamBatchSize,
+		maxStreamBatchByteSize: config.MaxStreamBatchByteSize,
+		maxGroup:               config.MaxGroup,
+
+		wgLogChan:        &sync.WaitGroup{},
+		wgBatchChan:      &sync.WaitGroup{},
+		logChannel:       make(chan interface{}, 1000),
+		batchChannel:     make(chan []interface{}, 100),
+		stopChannel:      make(chan bool),
+		stopBatchChannel: make(chan bool),
+	}
+
+	if s.logBufferSize == 0 {
+		s.logBufferSize = 500
+	}
+
+	if s.maxStreamBatchSize == 0 {
+		s.maxStreamBatchSize = 100
+	}
+
+	if s.maxStreamBatchByteSize == 0 {
+		s.maxStreamBatchByteSize = int(math.Pow(2, 18))
+	}
+
+	if s.maxGroup == 0 {
+		s.maxGroup = 1
+	}
+
+	if s.partitioner == nil {
+		s.partitioner = PartitionerPointer(Partitioners.UUID)
+	}
+
+	s.start()
+
+	return s, nil
+}
+
+// Error returns the channel for receiving errors.
+func (s *stream) Error() <-chan error {
+	return s.errChannel
+}
+
+func (s *stream) startStreaming() {
+	for {
+		select {
+		case record := <-s.logChannel:
+			s.mu.Lock()
+			s.logBuffer = append(s.logBuffer, record)
+			s.mu.Unlock()
+			if len(s.logBuffer) > s.logBufferSize {
+				batch := s.logBuffer
+				s.logBuffer = make([]interface{}, 0)
+
+				batches, err := CreateBatches(batch, s.maxStreamBatchSize, s.maxStreamBatchByteSize)
+				if err != nil {
+					s.errChannel <- err
+					continue
+				}
+
+				for _, b := range batches {
+					s.wgBatchChan.Add(1)
+					s.batchChannel <- b
+				}
+			}
+			s.wgLogChan.Done()
+		case <-s.stopChannel:
+			s.stopAndWaitBatchStreaming()
+			s.wgLogChan.Done()
+			return
+		}
+	}
+}
+
+func (s *stream) stopAndWaitBatchStreaming() {
+	s.wgBatchChan.Wait()
+	s.wgBatchChan.Add(1)
+	s.stopBatchChannel <- true
+	s.wgBatchChan.Wait()
+
+	close(s.batchChannel)
+}
+
+func (s *stream) stopAndWaitLogStreaming() {
+	s.wgLogChan.Wait()
+	s.wgLogChan.Add(1)
+	s.stopChannel <- true
+	s.wgLogChan.Wait()
+
+	close(s.logChannel)
+}
+
+func (s *stream) startBatchStreaming() {
+	concurrentLimiter := make(chan struct{}, s.maxGroup)
+	for {
+		select {
+		case batch := <-s.batchChannel:
+			concurrentLimiter <- struct{}{}
+			go func() {
+				defer func() {
+					s.wgBatchChan.Done()
+					<-concurrentLimiter
+				}()
+
+				s.totalCount += len(batch)
+				failedCount, err := s.PutRecords(batch)
+				if err != nil {
+					fmt.Printf("Error sending records to Kinesis stream %s: %v\n", s.name, err)
+					s.errChannel <- err
+					return
+				}
+
+				fmt.Printf("Sent %d records to Kinesis stream %s\n", len(batch), s.name)
+
+				s.failedCount += failedCount
+			}()
+		case <-s.stopBatchChannel:
+			if len(s.logBuffer) == 0 {
+				s.wgBatchChan.Done()
+				return
+			}
+
+			lastBatch := s.logBuffer
+			s.totalCount += len(lastBatch)
+			s.logBuffer = make([]interface{}, 0)
+
+			batches, _ := CreateBatches(lastBatch, s.maxStreamBatchSize, s.maxStreamBatchByteSize)
+
+			for _, b := range batches {
+				failedCount, err := s.PutRecords(b)
+				s.failedCount += failedCount
+				if err != nil {
+					fmt.Printf("Error sending records to Kinesis stream %s: %v\n", s.name, err)
+					s.errChannel <- err
+					s.wgBatchChan.Done()
+					return
+				}
+
+			}
+
+			s.wgBatchChan.Done()
+			return
+		}
+	}
+}
+
+func (s *stream) start() {
+	go s.startStreaming()
+	go s.startBatchStreaming()
+}
+
+func (s *stream) FlushAndStopStreaming() {
+	s.stopAndWaitLogStreaming()
+	close(s.errChannel)
+	fmt.Printf("%d/%d records sent to Kinesis stream %s\n", s.totalCount-s.failedCount, s.totalCount, s.name)
+}
+
+// PutRecords sends records to the Kinesis stream.
+func (s *stream) PutRecords(batch []interface{}) (int, error) {
+	transformed, err := s.transformRecords(batch)
+	if err != nil {
+		return len(batch), err
+	}
+
+	failedCount, err := s.putRecords(transformed, RetryCount)
+
+	return failedCount, err
+}
+
+// Put sends a single record to the Kinesis stream.
+func (s *stream) Put(record interface{}) {
+	s.wgLogChan.Add(1)
+	s.logChannel <- record
+}
+
+func (s *stream) putRecords(batch []*kinesis.PutRecordsRequestEntry, retryCount int) (int, error) {
+	fmt.Printf("Sending %d records to Kinesis stream %s\n", len(batch), s.name)
+	if retryCount == 0 {
+		fmt.Printf("Retry count exceeded for Kinesis stream %s\n", s.name)
+		return len(batch), errors.New("retry count exceeded")
+	}
+
+	res, err := s.kinesisClient.PutRecords(&kinesis.PutRecordsInput{
+		Records:    batch,
+		StreamName: aws.String(s.name),
+	})
+
+	if err != nil {
+		fmt.Printf("Error sending records to Kinesis stream %s: %v\n", s.name, err)
+		return len(batch), err
+	}
+
+	if res != nil && res.FailedRecordCount != nil && *res.FailedRecordCount > 0 {
+		fmt.Printf("Failed to send %d records to Kinesis stream %s\n", *res.FailedRecordCount, s.name)
+		failedRecords := s.wrapWithPutRecordsRequestEntry(getFailedRecords(res, batch))
+		batch = failedRecords
+		retryCount--
+
+		fmt.Printf("Retrying %d records to Kinesis stream %s\n", len(batch), s.name)
+		time.Sleep(RetryWaitTime)
+		failed, err := s.putRecords(batch, retryCount)
+		if err != nil {
+			return failed, err
+		}
+	}
+	return 0, err
+}
+
+func (s *stream) transformRecords(records []interface{}) ([]*kinesis.PutRecordsRequestEntry, error) {
+	var transformedRecords []*kinesis.PutRecordsRequestEntry
+	failedRecords := 0
+	var err error
+	var js []byte
+	for _, record := range records {
+		js, err = json.Marshal(record)
+		if err != nil {
+			failedRecords += 1
+			continue
+		}
+
+		transformedRecords = append(transformedRecords, &kinesis.PutRecordsRequestEntry{
+			Data:         append(js, outputSeparator),
+			PartitionKey: aws.String((*s.partitioner)(js)),
+		})
+	}
+
+	if failedRecords > 0 {
+		fmt.Printf("Failed to transform %d records to Kinesis stream %s\n", failedRecords, s.name)
+	}
+
+	return transformedRecords, err
+}
+
+func getFailedRecords(response *kinesis.PutRecordsOutput, records []*kinesis.PutRecordsRequestEntry) [][]byte {
+	failedRecords := make([][]byte, 0)
+
+	for i, record := range response.Records {
+		if record.ErrorCode != nil {
+			failedRecords = append(failedRecords, records[i].Data)
+		}
+	}
+
+	return failedRecords
+}
+
+func (s *stream) wrapWithPutRecordsRequestEntry(records [][]byte) []*kinesis.PutRecordsRequestEntry {
+	var transformedRecords []*kinesis.PutRecordsRequestEntry
+
+	for _, record := range records {
+		transformedRecords = append(transformedRecords, &kinesis.PutRecordsRequestEntry{
+			Data:         append(record, outputSeparator),
+			PartitionKey: aws.String((*s.partitioner)(record)),
+		})
+	}
+
+	return transformedRecords
+}
+
+func CreateBatches(v interface{}, recordLimit int, byteLimit int) ([][]interface{}, error) {
+	records, ok := TakeSliceArg(v)
+	if !ok {
+		return nil, errors.New("invalid input")
+	}
+
+	var batches = make([][]interface{}, 0)
+	buffer := make([]interface{}, 0)
+	bufferSize := 0
+
+	for _, record := range records {
+		js, jsErr := json.Marshal(record)
+		if jsErr != nil {
+			return nil, jsErr
+		}
+
+		recordSize := len(js)
+		sizeExceeds := bufferSize+recordSize > byteLimit
+		bufferFull := len(buffer) == recordLimit
+
+		if len(buffer) > 0 && (bufferFull || sizeExceeds) {
+			batches = append(batches, buffer)
+			buffer = make([]interface{}, 0)
+			bufferSize = 0
+		}
+
+		buffer = append(buffer, record)
+		bufferSize += recordSize
+	}
+
+	if len(buffer) > 0 {
+		batches = append(batches, buffer)
+	}
+
+	return batches, nil
+}

--- a/inskinesis/inskinesis.go
+++ b/inskinesis/inskinesis.go
@@ -124,7 +124,7 @@ func NewKinesis(config Config) (StreamInterface, error) {
 	}
 
 	if s.maxStreamBatchByteSize == 0 {
-		s.maxStreamBatchByteSize = int(math.Pow(2, 10))
+		s.maxStreamBatchByteSize = int(math.Pow(2, 16))
 	}
 
 	if s.maxGroup == 0 {

--- a/inskinesis/inskinesis_fake.go
+++ b/inskinesis/inskinesis_fake.go
@@ -1,0 +1,43 @@
+package inskinesis
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type FakeStream struct {
+	StreamInterface
+	Data        []string
+	Stream      StreamInterface
+	Partitioner *PartitionerFunction
+}
+
+func (s *FakeStream) Put(v interface{}) {
+	js, err := json.Marshal(v)
+	if err != nil {
+		println(fmt.Sprintf("Error marshalling in fake kinesis %v", v))
+	}
+	s.Data = append(s.Data, string(js))
+	if s.Stream != nil {
+		s.Stream.Put(v)
+	}
+}
+
+func (s *FakeStream) Get() {}
+
+// Datum gets item at the index i, and converts JSON at the index i to interface pointer r.
+// Returns JSON string.
+// Example:
+//
+//	t := MyStruct{}
+//	js := s.Datum(-1, &t)
+func (s *FakeStream) Datum(i int, r interface{}) string {
+	if i < 0 {
+		i = len(s.Data) + i
+	}
+	d := s.Data[i]
+	if r != nil {
+		_ = json.Unmarshal([]byte(d), &r)
+	}
+	return d
+}

--- a/inskinesis/inskinesis_mock.go
+++ b/inskinesis/inskinesis_mock.go
@@ -1,0 +1,95 @@
+package inskinesis
+
+import (
+	reflect "reflect"
+
+	kinesis "github.com/aws/aws-sdk-go/service/kinesis"
+	gomock "go.uber.org/mock/gomock"
+)
+
+// MockKinesisInterface is a mock of KinesisInterface interface.
+type MockKinesisInterface struct {
+	ctrl     *gomock.Controller
+	recorder *MockKinesisInterfaceMockRecorder
+}
+
+// MockKinesisInterfaceMockRecorder is the mock recorder for MockKinesisInterface.
+type MockKinesisInterfaceMockRecorder struct {
+	mock *MockKinesisInterface
+}
+
+// NewMockKinesisInterface creates a new mock instance.
+func NewMockKinesisInterface(ctrl *gomock.Controller) *MockKinesisInterface {
+	mock := &MockKinesisInterface{ctrl: ctrl}
+	mock.recorder = &MockKinesisInterfaceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockKinesisInterface) EXPECT() *MockKinesisInterfaceMockRecorder {
+	return m.recorder
+}
+
+// PutRecords mocks base method.
+func (m *MockKinesisInterface) PutRecords(input *kinesis.PutRecordsInput) (*kinesis.PutRecordsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutRecords", input)
+	ret0, _ := ret[0].(*kinesis.PutRecordsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutRecords indicates an expected call of PutRecords.
+func (mr *MockKinesisInterfaceMockRecorder) PutRecords(input any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRecords", reflect.TypeOf((*MockKinesisInterface)(nil).PutRecords), input)
+}
+
+// MockStreamInterface is a mock of StreamInterface interface.
+type MockStreamInterface struct {
+	ctrl     *gomock.Controller
+	recorder *MockStreamInterfaceMockRecorder
+}
+
+// MockStreamInterfaceMockRecorder is the mock recorder for MockStreamInterface.
+type MockStreamInterfaceMockRecorder struct {
+	mock *MockStreamInterface
+}
+
+// NewMockStreamInterface creates a new mock instance.
+func NewMockStreamInterface(ctrl *gomock.Controller) *MockStreamInterface {
+	mock := &MockStreamInterface{ctrl: ctrl}
+	mock.recorder = &MockStreamInterfaceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockStreamInterface) EXPECT() *MockStreamInterfaceMockRecorder {
+	return m.recorder
+}
+
+// FlushAndStopStreaming mocks base method.
+func (m *MockStreamInterface) FlushAndStopStreaming() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "FlushAndStopStreaming")
+}
+
+// FlushAndStopStreaming indicates an expected call of FlushAndStopStreaming.
+func (mr *MockStreamInterfaceMockRecorder) FlushAndStopStreaming() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushAndStopStreaming", reflect.TypeOf((*MockStreamInterface)(nil).FlushAndStopStreaming))
+}
+
+// Put mocks base method.
+func (m *MockStreamInterface) Put(record any) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Put", record)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Put indicates an expected call of Put.
+func (mr *MockStreamInterfaceMockRecorder) Put(record any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockStreamInterface)(nil).Put), record)
+}

--- a/inskinesis/inskinesis_test.go
+++ b/inskinesis/inskinesis_test.go
@@ -1,0 +1,205 @@
+package inskinesis
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_wrapWithPutRecordsRequestEntry(t *testing.T) {
+	s := stream{
+		partitioner: PartitionerPointer(Partitioners.UUID),
+	}
+
+	t.Run("it_should_return_put_records_request_entry_correctly", func(t *testing.T) {
+		records := [][]byte{[]byte("record1"), []byte("record2")}
+		expected := []*kinesis.PutRecordsRequestEntry{
+			{
+				Data: []byte("record1\n"),
+			},
+			{
+				Data: []byte("record2\n"),
+			},
+		}
+		actual := s.wrapWithPutRecordsRequestEntry(records)
+
+		assert.Equal(t, expected[0].Data, actual[0].Data)
+		assert.Equal(t, expected[1].Data, actual[1].Data)
+
+	})
+}
+
+func Test_getFailedRecords(t *testing.T) {
+	t.Run("it_should_return_failed_records_correctly", func(t *testing.T) {
+		response := &kinesis.PutRecordsOutput{
+			Records: []*kinesis.PutRecordsResultEntry{
+				{
+					ErrorCode: aws.String("error1"),
+				},
+				{
+					ErrorCode: aws.String("error2"),
+				},
+			},
+		}
+		records := []*kinesis.PutRecordsRequestEntry{
+			{
+				Data: []byte("record1\n"),
+			},
+			{
+				Data: []byte("record2\n"),
+			},
+		}
+		expected := [][]byte{[]byte("record1\n"), []byte("record2\n")}
+		actual := getFailedRecords(response, records)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("it_should_return_empty_slice_when_no_failed_records", func(t *testing.T) {
+		response := &kinesis.PutRecordsOutput{
+			Records: []*kinesis.PutRecordsResultEntry{
+				{
+					ErrorCode: nil,
+				},
+				{
+					ErrorCode: nil,
+				},
+			},
+		}
+		records := []*kinesis.PutRecordsRequestEntry{
+			{
+				Data: []byte("record1\n"),
+			},
+			{
+				Data: []byte("record2\n"),
+			},
+		}
+		expected := [][]byte{}
+		actual := getFailedRecords(response, records)
+		assert.Equal(t, expected, actual)
+	})
+}
+
+func Test_transformRecords(t *testing.T) {
+	s := stream{
+		partitioner: PartitionerPointer(Partitioners.UUID),
+	}
+
+	t.Run("it_should_return_transformed_records_correctly", func(t *testing.T) {
+		records := []interface{}{
+			map[string]string{
+				"key1": "value1",
+			},
+			map[string]string{
+				"key2": "value2",
+			},
+		}
+		expected := []*kinesis.PutRecordsRequestEntry{
+			{
+				Data: []byte("{\"key1\":\"value1\"}\n"),
+			},
+			{
+				Data: []byte("{\"key2\":\"value2\"}\n"),
+			},
+		}
+		actual, err := s.transformRecords(records)
+		assert.Nil(t, err)
+
+		assert.Equal(t, expected[0].Data, actual[0].Data)
+		assert.Equal(t, expected[1].Data, actual[1].Data)
+	})
+
+	t.Run("it_should_return_error_when_failed_to_transform_records", func(t *testing.T) {
+		records := []interface{}{make(chan int)}
+		transformed, err := s.transformRecords(records)
+		assert.Error(t, err)
+		assert.Nil(t, transformed)
+	})
+}
+
+func Test_CreateBatches(t *testing.T) {
+	t.Run("it_should_return_batches_correctly", func(t *testing.T) {
+		records := []interface{}{
+			map[string]string{
+				"key1": "value1",
+			},
+			map[string]string{
+				"key2": "value2",
+			},
+			map[string]string{
+				"key3": "value3",
+			},
+			map[string]string{
+				"key4": "value4",
+			},
+		}
+		expected := [][]interface{}{
+			{
+				map[string]string{
+					"key1": "value1",
+				},
+				map[string]string{
+					"key2": "value2",
+				},
+			},
+			{
+				map[string]string{
+					"key3": "value3",
+				},
+				map[string]string{
+					"key4": "value4",
+				},
+			},
+		}
+		actual, err := CreateBatches(records, 2, 100)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("it_should_return_error_when_failed_to_create_batches", func(t *testing.T) {
+		records := []interface{}{make(chan int)}
+		batches, err := CreateBatches(records, 2, 100)
+		assert.Error(t, err)
+		assert.Nil(t, batches)
+	})
+}
+
+//
+//func Test_putRecords(t *testing.T) {
+//	s := stream{
+//		name:          "test-stream",
+//		partitioner:   PartitionerPointer(Partitioners.UUID),
+//		kinesisClient: NewMockKinesisInterface(gomock.NewController(t)),
+//	}
+//
+//	t.Run("it_should_retry", func(t *testing.T) {
+//		records := []*kinesis.PutRecordsRequestEntry{
+//			{
+//				Data: []byte("record1\n"),
+//			},
+//			{
+//				Data: []byte("record2\n"),
+//			},
+//		}
+//
+//		resp := kinesis.PutRecordsOutput{
+//			FailedRecordCount: aws.Int64(2),
+//			Records: []*kinesis.PutRecordsResultEntry{
+//				{
+//					ErrorCode: aws.String("error1"),
+//				},
+//				{
+//					ErrorCode: aws.String("error2"),
+//				},
+//			},
+//		}
+//
+//		s.kinesisClient.(*MockKinesisInterface).EXPECT().PutRecords(&kinesis.PutRecordsInput{
+//			Records:    records,
+//			StreamName: aws.String(s.name),
+//		}).Times(1).Return(&resp, nil)
+//		failedCount, _ := s.putRecords(records, 3)
+//
+//		assert.Equal(t, 2, failedCount)
+//	})
+//}

--- a/inskinesis/inskinesis_test.go
+++ b/inskinesis/inskinesis_test.go
@@ -205,7 +205,7 @@ func Test_putRecords(t *testing.T) {
 		s.kinesisClient.(*MockKinesisInterface).EXPECT().PutRecords(&kinesis.PutRecordsInput{
 			Records:    records,
 			StreamName: aws.String(s.name),
-		}).Times(3).Return(&resp, nil)
+		}).Times(4).Return(&resp, nil)
 		failedCount, _ := s.putRecords(records, 3)
 
 		assert.Equal(t, 2, failedCount)

--- a/inskinesis/kinesis_mock.go
+++ b/inskinesis/kinesis_mock.go
@@ -1,0 +1,139 @@
+package inskinesis
+
+import (
+	kinesis "github.com/aws/aws-sdk-go/service/kinesis"
+	reflect "reflect"
+
+	protocol "github.com/aws/aws-sdk-go/private/protocol"
+	eventstream "github.com/aws/aws-sdk-go/private/protocol/eventstream"
+	gomock "go.uber.org/mock/gomock"
+)
+
+// MockSubscribeToShardEventStreamEvent is a mock of SubscribeToShardEventStreamEvent interface.
+type MockSubscribeToShardEventStreamEvent struct {
+	ctrl     *gomock.Controller
+	recorder *MockSubscribeToShardEventStreamEventMockRecorder
+}
+
+// MockSubscribeToShardEventStreamEventMockRecorder is the mock recorder for MockSubscribeToShardEventStreamEvent.
+type MockSubscribeToShardEventStreamEventMockRecorder struct {
+	mock *MockSubscribeToShardEventStreamEvent
+}
+
+// NewMockSubscribeToShardEventStreamEvent creates a new mock instance.
+func NewMockSubscribeToShardEventStreamEvent(ctrl *gomock.Controller) *MockSubscribeToShardEventStreamEvent {
+	mock := &MockSubscribeToShardEventStreamEvent{ctrl: ctrl}
+	mock.recorder = &MockSubscribeToShardEventStreamEventMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSubscribeToShardEventStreamEvent) EXPECT() *MockSubscribeToShardEventStreamEventMockRecorder {
+	return m.recorder
+}
+
+// MarshalEvent mocks base method.
+func (m *MockSubscribeToShardEventStreamEvent) MarshalEvent(arg0 protocol.PayloadMarshaler) (eventstream.Message, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarshalEvent", arg0)
+	ret0, _ := ret[0].(eventstream.Message)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarshalEvent indicates an expected call of MarshalEvent.
+func (mr *MockSubscribeToShardEventStreamEventMockRecorder) MarshalEvent(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshalEvent", reflect.TypeOf((*MockSubscribeToShardEventStreamEvent)(nil).MarshalEvent), arg0)
+}
+
+// UnmarshalEvent mocks base method.
+func (m *MockSubscribeToShardEventStreamEvent) UnmarshalEvent(arg0 protocol.PayloadUnmarshaler, arg1 eventstream.Message) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnmarshalEvent", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnmarshalEvent indicates an expected call of UnmarshalEvent.
+func (mr *MockSubscribeToShardEventStreamEventMockRecorder) UnmarshalEvent(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmarshalEvent", reflect.TypeOf((*MockSubscribeToShardEventStreamEvent)(nil).UnmarshalEvent), arg0, arg1)
+}
+
+// eventSubscribeToShardEventStream mocks base method.
+func (m *MockSubscribeToShardEventStreamEvent) eventSubscribeToShardEventStream() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "eventSubscribeToShardEventStream")
+}
+
+// eventSubscribeToShardEventStream indicates an expected call of eventSubscribeToShardEventStream.
+func (mr *MockSubscribeToShardEventStreamEventMockRecorder) eventSubscribeToShardEventStream() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "eventSubscribeToShardEventStream", reflect.TypeOf((*MockSubscribeToShardEventStreamEvent)(nil).eventSubscribeToShardEventStream))
+}
+
+// MockSubscribeToShardEventStreamReader is a mock of SubscribeToShardEventStreamReader interface.
+type MockSubscribeToShardEventStreamReader struct {
+	ctrl     *gomock.Controller
+	recorder *MockSubscribeToShardEventStreamReaderMockRecorder
+}
+
+// MockSubscribeToShardEventStreamReaderMockRecorder is the mock recorder for MockSubscribeToShardEventStreamReader.
+type MockSubscribeToShardEventStreamReaderMockRecorder struct {
+	mock *MockSubscribeToShardEventStreamReader
+}
+
+// NewMockSubscribeToShardEventStreamReader creates a new mock instance.
+func NewMockSubscribeToShardEventStreamReader(ctrl *gomock.Controller) *MockSubscribeToShardEventStreamReader {
+	mock := &MockSubscribeToShardEventStreamReader{ctrl: ctrl}
+	mock.recorder = &MockSubscribeToShardEventStreamReaderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSubscribeToShardEventStreamReader) EXPECT() *MockSubscribeToShardEventStreamReaderMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockSubscribeToShardEventStreamReader) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockSubscribeToShardEventStreamReaderMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockSubscribeToShardEventStreamReader)(nil).Close))
+}
+
+// Err mocks base method.
+func (m *MockSubscribeToShardEventStreamReader) Err() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Err")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Err indicates an expected call of Err.
+func (mr *MockSubscribeToShardEventStreamReaderMockRecorder) Err() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockSubscribeToShardEventStreamReader)(nil).Err))
+}
+
+// Events mocks base method.
+func (m *MockSubscribeToShardEventStreamReader) Events() <-chan kinesis.SubscribeToShardEventStreamEvent {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Events")
+	ret0, _ := ret[0].(<-chan kinesis.SubscribeToShardEventStreamEvent)
+	return ret0
+}
+
+// Events indicates an expected call of Events.
+func (mr *MockSubscribeToShardEventStreamReaderMockRecorder) Events() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockSubscribeToShardEventStreamReader)(nil).Events))
+}

--- a/inskinesis/partitioners.go
+++ b/inskinesis/partitioners.go
@@ -1,0 +1,26 @@
+package inskinesis
+
+import uuid "github.com/google/uuid"
+
+// PartitionerFunction is the common signature of all partitioners, it maps a record to a partition key.
+type PartitionerFunction func(record interface{}) string
+
+type partitionersCollection struct{}
+
+var Partitioners = partitionersCollection{}
+
+// UUID partitioner returns a new uuid instead, regardless of parameters.
+// Example: `newPartitionKey := Partitioners.UUID(nil)`
+func (p *partitionersCollection) UUID(_ interface{}) string {
+	return uuid.New().String()
+}
+
+func UUID(_ interface{}) string {
+	return uuid.New().String()
+}
+
+// PartitionerPointer returns a pointer to the PartitionerPointer value passed in.
+func PartitionerPointer(function PartitionerFunction) *PartitionerFunction {
+	fn := &function
+	return fn
+}

--- a/inskinesis/partitioners.go
+++ b/inskinesis/partitioners.go
@@ -15,10 +15,6 @@ func (p *partitionersCollection) UUID(_ interface{}) string {
 	return uuid.New().String()
 }
 
-func UUID(_ interface{}) string {
-	return uuid.New().String()
-}
-
 // PartitionerPointer returns a pointer to the PartitionerPointer value passed in.
 func PartitionerPointer(function PartitionerFunction) *PartitionerFunction {
 	fn := &function


### PR DESCRIPTION
# Kinesis Package

The `inskinesis` package is a Go library designed to facilitate streaming data to Amazon Kinesis streams. This README
provides an overview of the package's functionality and usage.

## Table of Contents

- [Introduction](#introduction)
- [Installation](#installation)
- [Getting Started](#getting-started)
- [Package Structure](#package-structure)
- [Usage](#usage)
- [Error Handling](#error-handling)r
- [Contributing](#contributing
  )

## Introduction

The `inskinesis` package is designed to make it easier to stream data to Amazon Kinesis streams in your Go applications.
It provides a simple interface for sending records to a Kinesis stream while handling batching, partitioning, and
retries. This can be especially useful for applications that generate a high volume of data and need to send it to
Kinesis efficiently.

## Installation

To use the `inskinesis` package in your Go project, you can install it using Go modules. Run the following command in
your project directory:

```bash
go get github.com/useinsider/go-pkg/inskinesis
```

## Getting Started

Here's a quick guide on how to get started with the `inskinesis` package:

1. Import the package in your Go code:

   ```go
   import "github.com/useinsider/go-pkg/inskinesis"
   ```

2. Create a configuration for your Kinesis stream:

   ```go
   config := inskinesis.Config{
       Region:                 "your-aws-region",
       StreamName:             "your-kinesis-stream-name",
       Partitioner:            nil, // Optionally provide a partitioner function
       MaxStreamBatchSize:     100, // Maximum size of each batch of records
       MaxStreamBatchByteSize: 1024 * 1024, // Maximum size in bytes for each batch
       MaxBatchSize:           500, // Maximum size of the log buffer
       MaxGroup:               10, // Maximum number of concurrent groups for sending records
   }
   ```

| Field                  | Default Value      | Description                                                                                                                                       |
|------------------------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
| Region                 | N/A                | The AWS region where the Kinesis stream is located. **Required**                                                                                  |
| StreamName             | N/A                | The name of the Kinesis stream. **Required**                                                                                                      |
| Partitioner            | UUID               | An optional partitioner function used to determine the partition key for records. If not provided, a default UUID-based partitioner is used.      |
| MaxStreamBatchSize     | 100                | The maximum size of each batch of records to be sent to the stream.                                                                               |
| MaxStreamBatchByteSize | 256 KB (2^18 byte) | The maximum size (in bytes) of each batch of records.                                                                                             |
| MaxBatchSize           | 500                | The maximum size of the log buffer for accumulating log records before batching.                                                                  |
| MaxGroup               | 1                  | The maximum number of concurrent groups for sending records. If you want to send records concurrently, set this value to a number greater than 1. |
| RetryCount             | 3                  | The number of times to retry sending a batch of records to the stream.                                                                            |
| RetryInterval          | 100 ms             | The interval between retries.                                                                                                                     |

Please note that `N/A` in the Default Value column indicates that these fields are required and do not have default
values.

3. Create a Kinesis stream instance:

   ```go
   stream, err := inskinesis.NewKinesis(config)
   if err != nil {
       // Handle the error
   }
   ```

4. Send records to the Kinesis stream:

   ```go
   // Send a single record
   stream.Put(yourRecord)

   // Send multiple records
   records := []interface{}{record1, record2, record3}
   for _, record := range records {
       stream.Put(record)
   }
   ```

5. To ensure all records are sent and clean up resources, flush and stop streaming:

   ```go
   stream.FlushAndStopStreaming()
   ```

## Package Structure

The `inskinesis` package is organized as follows:

- `inskinesis` package: The main package containing the `StreamInterface`, `stream`, and related functionality for
  streaming records to Kinesis.
- `PartitionerFunction`: A customizable partitioning function for determining the partition key of records.
- Various error handling and logging functionality.

## Usage

The package provides a simple interface for streaming records to a Kinesis stream. You can customize the configuration
based on your needs, including the region, stream name, batch sizes, and partitioning function.

Here's an example of how to use the package:

```go
import "github.com/useinsider/go-pkg/inskinesis"

config := inskinesis.Config{
    Region:                 "your-aws-region",
    StreamName:             "your-kinesis-stream-name",
    Partitioner:            nil, // Optionally provide a partitioner function
    MaxStreamBatchSize:     100, // Maximum size of each batch of records
    MaxStreamBatchByteSize: 1024 * 1024, // Maximum size in bytes for each batch
    MaxBatchSize:           500,         // Maximum size of the log buffer
    MaxGroup:               10, // Maximum number of concurrent groups for sending records
}

stream, err := inskinesis.NewKinesis(config)
if err != nil {
// Handle the error
}

// Send records to the stream
stream.Put(yourRecord)

// To ensure all records are sent and clean up resources, flush and stop streaming
stream.FlushAndStopStreaming()
```

## Error Handling

The `inskinesis` package provides error channels for receiving errors during streaming. You can use these channels to
handle errors in your application gracefully. It's important to monitor the error channels to ensure the robustness of
your data streaming process.

Here's an example of how to use the error channels:

```go
go func () {
    for {
        select {
        case err := <-stream.Error():
            sentry.Error(err)
        }
    }
}()

```

## Contributing

If you would like to contribute to the `inskinesis` package, please follow standard Go community guidelines for
contributions. You can create issues, submit pull requests, and help improve the package for everyone.
