### PR TITLE
fix/PA-23889 give buffer size to the channels

### DIFF
--- a/inskinesis/README.md
+++ b/inskinesis/README.md
@@ -65,6 +65,7 @@ Here's a quick guide on how to get started with the `inskinesis` package:
 | MaxGroup               | 1                  | The maximum number of concurrent groups for sending records. If you want to send records concurrently, set this value to a number greater than 1. |
 | RetryCount             | 3                  | The number of times to retry sending a batch of records to the stream.                                                                            |
 | RetryInterval          | 100 ms             | The interval between retries.                                                                                                                     |
+| Verbose                | false              | Whether to enable verbose logging.                                                                                                                |
 
 Please note that `N/A` in the Default Value column indicates that these fields are required and do not have default
 values.

--- a/inskinesis/inskinesis.go
+++ b/inskinesis/inskinesis.go
@@ -76,6 +76,7 @@ type Config struct {
 	MaxGroup               int
 	RetryCount             int
 	RetryWaitTime          time.Duration
+	Verbose                bool
 }
 
 // NewKinesis creates a new Kinesis stream.
@@ -116,6 +117,8 @@ func NewKinesis(config Config) (StreamInterface, error) {
 
 		retryCount:    config.RetryCount,
 		retryWaitTime: 100 * time.Millisecond,
+
+		verbose: config.Verbose,
 	}
 
 	if s.logBufferSize == 0 {


### PR DESCRIPTION
When we don't listen the errChannel, the goroutine stucks in this line 
```go
s.errChannel <- err
```

Because of the optionality of using error channel, we need to set a buffer size.