### PR TITLE
PA-30689 Return the last error when requester used with retry and circuit breaker

### DIFF
--- a/insrequester/errors.go
+++ b/insrequester/errors.go
@@ -6,5 +6,6 @@ var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrTimeout            = errors.New("timeout")
 
-	ErrRetryable = errors.New("retryable error")
+	ErrRetryable   = errors.New("retryable error")
+	ErrReadingBody = errors.New("error reading body")
 )

--- a/insrequester/requester.go
+++ b/insrequester/requester.go
@@ -128,10 +128,8 @@ func (r *Request) sendRequest(httpMethod string, re RequestEntity) (*http.Respon
 			if outerErr != nil {
 				return nil, errors.Wrap(ErrCircuitBreakerOpen, outerErr.Error())
 			}
-			if res != nil && (res.StatusCode >= 100 && res.StatusCode < 200 ||
-				res.StatusCode == 429 ||
-				res.StatusCode >= 500 && res.StatusCode <= 599) {
-				return nil, errors.Wrap(ErrCircuitBreakerOpen, r.getResponseBody(*res))
+			if res != nil {
+				return nil, errors.Wrap(ErrCircuitBreakerOpen, r.getResponseBody(res))
 			}
 		}
 		return nil, ErrCircuitBreakerOpen
@@ -164,7 +162,7 @@ func (r RequestEntity) applyHeadersToRequest(request *http.Request) {
 	}
 }
 
-func (r *Request) getResponseBody(res http.Response) string {
+func (r *Request) getResponseBody(res *http.Response) string {
 	var err error
 
 	bodyBytes, err := io.ReadAll(res.Body)

--- a/insrequester/requester.go
+++ b/insrequester/requester.go
@@ -131,7 +131,7 @@ func (r *Request) sendRequest(httpMethod string, re RequestEntity) (*http.Respon
 			if res != nil && (res.StatusCode >= 100 && res.StatusCode < 200 ||
 				res.StatusCode == 429 ||
 				res.StatusCode >= 500 && res.StatusCode <= 599) {
-				return nil, errors.Wrap(ErrCircuitBreakerOpen, r.getBodyError(*res))
+				return nil, errors.Wrap(ErrCircuitBreakerOpen, r.getResponseBody(*res))
 			}
 		}
 		return nil, ErrCircuitBreakerOpen
@@ -164,16 +164,16 @@ func (r RequestEntity) applyHeadersToRequest(request *http.Request) {
 	}
 }
 
-func (r *Request) getBodyError(res http.Response) string {
+func (r *Request) getResponseBody(res http.Response) string {
 	var err error
 
 	bodyBytes, err := io.ReadAll(res.Body)
 
 	if err != nil {
-		return res.Status + " : " + ErrReadingBody.Error()
+		return fmt.Sprintf("%s : %v", res.Status, ErrReadingBody)
 	}
 
-	return res.Status + " : " + string(bodyBytes)
+	return fmt.Sprintf("%s : %s", res.Status, string(bodyBytes))
 }
 
 func (r *Request) WithRetry(config RetryConfig) *Request {

--- a/insrequester/requester_test.go
+++ b/insrequester/requester_test.go
@@ -110,6 +110,7 @@ func TestRequest_Get(t *testing.T) {
 				MinimumRequestToOpen:         3,
 				SuccessfulRequiredOnHalfOpen: 1,
 				WaitDurationInOpenState:      300 * time.Second,
+				WrapError:                    true,
 			}).Load()
 
 		var err error

--- a/insrequester/requester_test.go
+++ b/insrequester/requester_test.go
@@ -110,7 +110,6 @@ func TestRequest_Get(t *testing.T) {
 				MinimumRequestToOpen:         3,
 				SuccessfulRequiredOnHalfOpen: 1,
 				WaitDurationInOpenState:      300 * time.Second,
-				WrapError:                    true,
 			}).Load()
 
 		var err error


### PR DESCRIPTION
Currently, if we are using the requester with retry and circuit breaker on we only get the "circuit breaker is opened" log and not any info about what the error was when we retry. Now I am checking if there is any error from the last retried request and if there is we are logging it with the circuit breaker error.
