### PR TITLE
insssm: add descriptive messages to panic calls

### DIFF
--- a/insssm/go.sum
+++ b/insssm/go.sum
@@ -17,6 +17,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/useinsider/go-pkg/inscacheable v1.0.0 h1:VDfK0WZFBo57eJ/3bkYmn9TEOvwVcRMx2fV1lAOfZP8=
+github.com/useinsider/go-pkg/inscacheable v1.0.0/go.mod h1:umkza9VeQm3maJgYhM/c6tXhl/Uc6mze943Qrvk/xWQ=
 go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 h1:2M3HP5CCK1Si9FQhwnzYhXdG6DXeebvUHFpre8QvbyI=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=

--- a/insssm/ssm.go
+++ b/insssm/ssm.go
@@ -1,10 +1,12 @@
 package insssm
 
 import (
-	awsssm "github.com/Jamil-Najafov/go-aws-ssm"
-	"github.com/useinsider/go-pkg/inscacheable"
+	"fmt"
 	"os"
 	"time"
+
+	awsssm "github.com/Jamil-Najafov/go-aws-ssm"
+	"github.com/useinsider/go-pkg/inscacheable"
 )
 
 // ParameterStore is the aws client for parameter store
@@ -13,7 +15,7 @@ var ParameterStore *awsssm.ParameterStore
 // ttl value is used to tell cacheable to long it should cache the value.
 var ttl = 1 * time.Minute
 
-//cache is the instance of cacheable wrapped ssm get function.
+// cache is the instance of cacheable wrapped ssm get function.
 var cache = inscacheable.Cacheable(get, &ttl)
 
 // Init
@@ -22,7 +24,7 @@ func Init() {
 	if os.Getenv("ENV") != "LOCAL" {
 		pmStore, err := awsssm.NewParameterStore()
 		if err != nil {
-			panic(err)
+			panic(fmt.Sprintf("insssm: failed to initialize SSM parameter store: %v", err))
 		}
 
 		ParameterStore = pmStore
@@ -40,7 +42,7 @@ func Get(key string) string {
 func get(key string) string {
 	params, err := ParameterStore.GetParameter(key, true)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("insssm: failed to get SSM parameter %q: %v", key, err))
 	}
 
 	return params.GetValue()


### PR DESCRIPTION
## Summary
- Replace bare `panic(err)` calls in `insssm` with descriptive `fmt.Sprintf` messages
- `Init()` panic now reports: `insssm: failed to initialize SSM parameter store: <error>`
- `get()` panic now reports: `insssm: failed to get SSM parameter "<key>": <error>`

🤖 Generated with [Claude Code](https://claude.ai/code)