### PR TITLE
fix(insrequester): add /v2 module path for Go modules convention

### DIFF
--- a/insrequester/README.md
+++ b/insrequester/README.md
@@ -7,7 +7,7 @@ The insrequester package is designed to provide a resilient way to make HTTP req
 
 ```go
 import (
-    "github.com/useinsider/go-pkg/insrequester"
+    "github.com/useinsider/go-pkg/insrequester/v2"
 )
 ```
 

--- a/insrequester/go.mod
+++ b/insrequester/go.mod
@@ -1,4 +1,4 @@
-module github.com/useinsider/go-pkg/insrequester
+module github.com/useinsider/go-pkg/insrequester/v2
 
 go 1.24.0
 


### PR DESCRIPTION
## Summary
- Add `/v2` suffix to insrequester module path in `go.mod` (`github.com/useinsider/go-pkg/insrequester/v2`)
- Update import path in README.md
- Go modules v2+ require the module path to end with `/v2` — without this, `go get` fails with: `module contains a go.mod file, so module path must match major version`
- After merge, delete the existing `insrequester/v2.0.0` tag and retag on the new commit

## Test plan
- [x] `go get github.com/useinsider/go-pkg/insrequester/v2@v2.0.0` resolves correctly after retagging