### PR TITLE
fix(core): resolve circuit breaker bypasses, data races, and optimize GC allocations

### DIFF
--- a/inskinesis/inskinesis.go
+++ b/inskinesis/inskinesis.go
@@ -250,7 +250,13 @@ func (s *stream) sendSingleBatch(batch []interface{}, concurrentLimiter chan str
 		}()
 
 		failedCount, err := s.PutRecords(batch)
+
+		// Guard failedCount: concurrent goroutines write to it simultaneously
+		// without synchronisation, causing a data race.
+		s.mu.Lock()
 		s.failedCount += failedCount
+		s.mu.Unlock()
+
 		if err != nil {
 			s.printf("Error sending records to Kinesis stream %s: %v\n", s.name, err)
 			if len(s.errChannel) < errorChannelSize {
@@ -327,7 +333,8 @@ func (s *stream) putRecords(batch []*kinesis.PutRecordsRequestEntry, retryCount 
 }
 
 func (s *stream) transformRecords(records []interface{}) ([]*kinesis.PutRecordsRequestEntry, error) {
-	var transformedRecords []*kinesis.PutRecordsRequestEntry
+	// Pre-allocate to avoid repeated backing-array reallocations on large batches.
+	transformedRecords := make([]*kinesis.PutRecordsRequestEntry, 0, len(records))
 	failedRecords := 0
 	var err error
 	var js []byte
@@ -364,7 +371,8 @@ func getFailedRecords(response *kinesis.PutRecordsOutput, records []*kinesis.Put
 }
 
 func (s *stream) wrapWithPutRecordsRequestEntry(records [][]byte) []*kinesis.PutRecordsRequestEntry {
-	var transformedRecords []*kinesis.PutRecordsRequestEntry
+	// Pre-allocate to avoid repeated backing-array reallocations on large batches.
+	transformedRecords := make([]*kinesis.PutRecordsRequestEntry, 0, len(records))
 
 	for _, record := range records {
 		transformedRecords = append(transformedRecords, &kinesis.PutRecordsRequestEntry{

--- a/insrequester/requester.go
+++ b/insrequester/requester.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/slok/goresilience"
@@ -15,9 +18,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
-	"io"
-	"net/http"
-	"time"
 )
 
 var tracer = otel.Tracer("insrequester")
@@ -103,29 +103,36 @@ func (r *Request) sendRequest(ctx context.Context, httpMethod string, re Request
 	defer span.End()
 
 	var (
-		res          *http.Response
-		outerErr     error
-		attempt      int
-		lastErrBody  string
+		res         *http.Response
+		outerErr    error
+		attempt     int
+		lastErrBody string
 	)
 
 	if r.runner == nil {
 		r.runner = goresilience.RunnerChain(r.middlewares...)
 	}
 
+	// Headers are merged once before the retry loop; merging inside the closure
+	// would prepend r.headers on every attempt, growing the slice indefinitely.
+	mergedEntity := re
+	mergedEntity.Headers = append(append(Headers(nil), r.headers...), re.Headers...)
+
 	runnerErr := r.runner.Run(ctx, func(attemptCtx context.Context) error {
 		attempt++
 		var req *http.Request
 
-		req, outerErr = http.NewRequestWithContext(attemptCtx, httpMethod, re.Endpoint, bytes.NewReader(re.Body))
+		req, outerErr = http.NewRequestWithContext(attemptCtx, httpMethod, mergedEntity.Endpoint, bytes.NewReader(mergedEntity.Body))
 		if outerErr != nil {
 			res = nil
-			return nil
+			// Returning the error (not nil) lets goresilience count this as a
+			// failure so the circuit breaker reflects the real error rate.
+			// Retrying is pointless: a malformed URL will never succeed.
+			return outerErr
 		}
 
 		req.Close = true
-		re.Headers = append(r.headers, re.Headers...) // RequestEntity headers will override Requester level headers.
-		re.applyHeadersToRequest(req)
+		mergedEntity.applyHeadersToRequest(req)
 
 		client := r.httpClient
 		if client == nil {
@@ -137,6 +144,11 @@ func (r *Request) sendRequest(ctx context.Context, httpMethod string, re Request
 		}
 		res, outerErr = client.Do(req)
 		if outerErr != nil {
+			// Do not retry on context cancellation or deadline: the caller has
+			// already abandoned the request, so further attempts are wasteful.
+			if errors.Is(outerErr, context.Canceled) || errors.Is(outerErr, context.DeadlineExceeded) {
+				return outerErr
+			}
 			return ErrRetryable
 		}
 
@@ -210,7 +222,10 @@ func (r *Request) sendRequest(ctx context.Context, httpMethod string, re Request
 }
 
 func (r RequestEntity) applyHeadersToRequest(request *http.Request) {
-	if request.Body != nil {
+	// http.NewRequestWithContext sets request.Body to http.NoBody (not nil) for
+	// empty readers, so request.Body != nil is always true. Check the raw slice
+	// to avoid sending Content-Type on bodyless requests such as GET.
+	if len(r.Body) > 0 {
 		request.Header.Set("Content-Type", "application/json")
 	}
 

--- a/inssqs/inssqs.go
+++ b/inssqs/inssqs.go
@@ -388,7 +388,13 @@ func doConcurrently[T any](batches [][]T, workers int, retryCount int, f func([]
 
 	concurrentLimiter := make(chan struct{}, workers)
 	wg := sync.WaitGroup{}
-	var outerErr error
+
+	// errMu guards outerErr: multiple goroutines may write concurrently and an
+	// unsynchronised write is a data race that causes undefined behaviour.
+	var (
+		outerErr   error
+		errMu      sync.Mutex
+	)
 	failedEntriesChan := make(chan []T)
 
 	for _, batch := range batches {
@@ -399,7 +405,9 @@ func doConcurrently[T any](batches [][]T, workers int, retryCount int, f func([]
 			defer func() { <-concurrentLimiter }()
 			fe, err := f(b, retryCount+1)
 			if err != nil {
+				errMu.Lock()
 				outerErr = err
+				errMu.Unlock()
 			}
 			failedEntriesChan <- fe
 		}(batch)


### PR DESCRIPTION
## Description
Addresses critical reliability, concurrency, and performance issues across `insrequester`, `inssqs`, and `inskinesis`.

### Key Changes

**1. `insrequester`**
* **Circuit breaker bypass:** `http.NewRequestWithContext` failures returned `nil`, registering a fake success in goresilience and preventing the circuit breaker from opening. Now returns `outerErr` directly.
* **Wasteful retries on cancelled context:** `context.Canceled` and `context.DeadlineExceeded` were treated as retryable errors. Added early exit for both to avoid unnecessary retry cycles on abandoned requests.
* **Header growth on retry:** Headers were merged inside the retry closure, causing `r.headers` to be prepended on every attempt. Moved the merge outside the closure so it runs once.
* **Phantom Content-Type on GET:** `request.Body != nil` always evaluated to `true` because `bytes.NewReader(nil)` produces `http.NoBody`, not nil. Replaced with `len(r.Body) > 0` to correctly gate the header.

**2. `inssqs` / `inskinesis`**
* **Data races:** `outerErr` in `inssqs.doConcurrently` and `s.failedCount` in `inskinesis.sendSingleBatch` were written by concurrent goroutines without synchronization. Protected both with `sync.Mutex`.
* **GC pressure on large batches:** `transformRecords` and `wrapWithPutRecordsRequestEntry` used nil slice declarations, causing up to 9 backing-array reallocations per batch. Replaced with `make([]*T, 0, len(records))` to allocate once.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement (memory allocation optimization)