### PR TITLE
fix(insrequester): add W3C trace propagation and CLIENT span kind

### DIFF
--- a/insrequester/requester.go
+++ b/insrequester/requester.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"io"
 	"net/http"
@@ -96,7 +97,7 @@ func (r *Request) sendRequest(ctx context.Context, httpMethod string, re Request
 		spanName = httpMethod + " " + parsed.Host + parsed.Path
 	}
 
-	ctx, span := tracer.Start(ctx, spanName, trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(
 		attribute.String("http.request.method", httpMethod),
 		attribute.String("url.full", re.Endpoint),
 	))
@@ -124,6 +125,7 @@ func (r *Request) sendRequest(ctx context.Context, httpMethod string, re Request
 		}
 
 		req.Close = true
+		otel.GetTextMapPropagator().Inject(attemptCtx, propagation.HeaderCarrier(req.Header))
 		re.Headers = append(r.headers, re.Headers...) // RequestEntity headers will override Requester level headers.
 		re.applyHeadersToRequest(req)
 


### PR DESCRIPTION
## Summary

- Inject W3C `traceparent`/`tracestate` headers into outgoing HTTP requests via `otel.GetTextMapPropagator().Inject()` — enables distributed tracing across service boundaries
- Set `trace.SpanKindClient` on outbound HTTP spans — makes them visible in Tempo service graph and generates correct RED metrics for dependency monitoring

## Context

Without these changes, insrequester creates OTel spans for outbound calls but:
1. Never sends the `traceparent` header, so downstream services start new unrelated traces instead of continuing the caller's trace
2. Spans have `SPAN_KIND_INTERNAL` (default) instead of `SPAN_KIND_CLIENT`, so they don't appear in the Tempo service graph and don't generate client-side RED metrics

## Changes

Two lines in `insrequester/requester.go`:
- Added `trace.WithSpanKind(trace.SpanKindClient)` to `tracer.Start()`
- Added `otel.GetTextMapPropagator().Inject(attemptCtx, propagation.HeaderCarrier(req.Header))` after request creation, before user headers are applied

The inject is placed before `applyHeadersToRequest` so that any explicit headers set by the caller take precedence over propagated headers.

## Test plan

- [ ] All existing tests pass (`go test ./... -count=1`)
- [ ] Deploy a consuming service and verify `traceparent` header is present on outgoing requests
- [ ] Verify spans appear as `SPAN_KIND_CLIENT` in Tempo
- [ ] Verify Tempo service graph shows edges from caller to downstream services