### PR TITLE
PA-38275: Add AI test-coverage prompt files

### DIFF
--- a/prompts/dependencies.md
+++ b/prompts/dependencies.md
@@ -1,0 +1,39 @@
+# go-pkg Dependencies
+
+`go-pkg` is a **shared library**, not a runtime service. It has no deployed
+pipeline position. Its primary "dependency" relationship is **downstream**:
+many Insider backend services import its `ins*` modules, so changes here
+propagate outward. Treat backward compatibility of exported APIs as the
+binding constraint.
+
+## Downstream consumers
+
+- Consumed broadly across Insider Go services (and Dataforce services in
+  particular) via per-module import paths, e.g.
+  `github.com/useinsider/go-pkg/insredis`.
+- Each module is versioned independently (`<module>/v<version>` tags), so a
+  breaking change must be a major bump on that module's path, not a silent
+  edit.
+
+## Internal module dependencies
+
+Some modules depend on sibling modules — release the dependency first:
+
+- `inssqs` → `insdash`, `inslogger`
+- `insssm` → `inscacheable`
+
+## Notable external dependencies (per module)
+
+- `insredis` → `go-redis/redis`
+- `inssqs` → `aws-sdk-go-v2` (config, sqs), `smithy-go`
+- `insssm` → `aws-sdk-go-v2` (ssm)
+- `inskinesis` → `aws-sdk-go-v2` (kinesis)
+- `inslogger` → `go.uber.org/zap`
+- `insgorm` / `inssql` → `gorm.io/gorm`, `go-sql-driver/mysql`,
+  `DATA-DOG/go-sqlmock` (test)
+- `insrequester` → `slok/goresilience` (retry / circuit breaker)
+- `inssentry` → `getsentry/sentry-go`
+- Shared: `stretchr/testify`, `golang/mock` / `go.uber.org/mock`, `pkg/errors`
+
+Third-party versions are pinned across modules via `scripts/check-deps.sh`;
+update it in the same PR as any version bump.

--- a/prompts/test-coverage.md
+++ b/prompts/test-coverage.md
@@ -1,0 +1,49 @@
+# go-pkg Test Coverage Guidelines
+
+## Repository
+
+`go-pkg` is Insider's shared, public Go utility library, consumed by many
+backend services. It is a **multi-module monorepo**: each `ins*` package
+(`insredis`, `inssqs`, `inslogger`, `insgorm`, `inssql`, `insrequester`, etc.)
+is an independent Go module with its own `go.mod`. There is no root module.
+Every exported symbol is a long-lived contract — backward compatibility is
+the default.
+
+## Output Discipline
+
+- Only flag coverage gaps for **non-test `*.go` source** added or changed in
+  this PR. Do not request tests for code outside the PR scope.
+- Tests run **per package** (`cd <pkg> && go test ./...`), never from the repo
+  root — there is no root module. Tie each requirement to its module.
+
+## Test Conventions
+
+- Tests live alongside code: `<pkg>/<name>_test.go`. Use `package ins<name>`
+  (white-box) for unexported helpers; prefer `package ins<name>_test`
+  (black-box) for the public surface, since that's what callers see.
+- **Table-driven** tests with `t.Run(tt.name, ...)` subtests; one behaviour
+  per subtest. Name cases after the condition, not the expected output.
+- Frameworks: `testify` for assertions; `golang/mock` / `go.uber.org/mock`
+  for interface mocks (committed, not regenerated in CI); `go-sqlmock` for
+  `inssql` / `insgorm`. No real DB/AWS in unit tests — use mocks/fakes.
+- Error paths: assert on the error value (`errors.Is` against a sentinel) or
+  wrapping structure, not the string.
+- Concurrency-sensitive code (retry, circuit breaker, cache eviction) must be
+  `go test -race` green.
+
+## Focus Coverage On
+
+- **Exported package APIs** — the contract callers depend on. New exported
+  functions must have a test; unexercised public API is a review red flag.
+- Behavioural logic: retry/backoff, circuit-breaker state, cache TTL/eviction,
+  query building, serialization, error wrapping.
+
+## What NOT to Test
+
+- `go.mod` / `go.sum`, generated mock files, CI workflows (`.github/`),
+  `scripts/`.
+- Thin pass-through wrappers over third-party SDK calls with no added logic.
+- Trivial getters/constructors that only assign fields.
+
+**Backward-compatibility warning**: flag any change to an exported signature,
+struct field, interface, or error sentinel — it can break downstream services.


### PR DESCRIPTION
Adds repo-specific `prompts/test-coverage.md` and `prompts/dependencies.md` for the Accurate Test Coverage Analyzer (AI review bot), plus `.github/workflows/ai-test-coverage.yml` where it was missing.

Jira: https://winsider.atlassian.net/browse/PA-38275

🤖 Generated with [Claude Code](https://claude.com/claude-code)