### PR TITLE
inssqs: add request timeout, fix delete failure path

### DIFF
--- a/inssqs/README.md
+++ b/inssqs/README.md
@@ -29,6 +29,7 @@ config := inssqs.Config{
     MaxBatchSizeBytes: 1024,
     MaxWorkers:        5,
     LogLevel:          "info",
+    RequestTimeout:    5 * time.Second,
 }
 
 sqs := inssqs.NewSQS(config)
@@ -69,6 +70,7 @@ if err != nil {
 - MaxBatchSizeBytes: Maximum size of a message batch in bytes.
 - MaxWorkers: Maximum number of workers for concurrent operations.
 - LogLevel: Log level for SQS operations.
+- RequestTimeout: Timeout for a single SQS API request attempt (default 5s). Bounds each HTTP request, so a stalled connection fails fast and is retried instead of hanging indefinitely.
 For more details on each function and its parameters, refer to the code documentation.
 
 

--- a/inssqs/go.sum
+++ b/inssqs/go.sum
@@ -41,6 +41,10 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/useinsider/go-pkg/insdash v1.0.0 h1:hMHFDkuUAgua97KR0ok/NdqRRtJg0ZC3YBhXNPYi/OE=
+github.com/useinsider/go-pkg/insdash v1.0.0/go.mod h1:oZMiLIARsp470E9vknJARxkMqtp8jSsVmNMGcE4ie8c=
+github.com/useinsider/go-pkg/inslogger v1.0.0 h1:5xweYJj0s8TKeH+VZ4FOWm7nR56XDF8LrW71bt8YEes=
+github.com/useinsider/go-pkg/inslogger v1.0.0/go.mod h1:9qrRWJYNPS8QFRMvi7P4HT8lVQqWTY5V1hnvv/gxWiI=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/mock v0.3.0 h1:3mUxI1No2/60yUYax92Pt8eNOEecx2D3lcXZh2NEZJo=
 go.uber.org/mock v0.3.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=

--- a/inssqs/inssqs.go
+++ b/inssqs/inssqs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
@@ -13,6 +14,7 @@ import (
 	"github.com/useinsider/go-pkg/inslogger"
 	"github.com/useinsider/go-pkg/inssqs/sqs"
 	"sync"
+	"time"
 )
 
 type Interface interface {
@@ -45,6 +47,8 @@ type Config struct {
 	MaxWorkers        int    // Maximum number of workers for concurrent operations.
 	LogLevel          string // Log level for SQS operations.
 
+	RequestTimeout time.Duration // Timeout for a single SQS API request attempt. The AWS SDK default HTTP client has none, so a stalled connection otherwise hangs until the caller is killed.
+
 	EndpointUrl string // Endpoint URL for AWS operations.
 }
 
@@ -62,7 +66,8 @@ func NewSQS(config Config) Interface {
 	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
 		awsconfig.WithRegion(config.Region),
 		awsconfig.WithRetryMaxAttempts(config.RetryCount),
-		awsconfig.WithRetryMode(aws.RetryModeAdaptive))
+		awsconfig.WithRetryMode(aws.RetryModeAdaptive),
+		awsconfig.WithHTTPClient(awshttp.NewBuildableClient().WithTimeout(config.RequestTimeout)))
 	if err != nil {
 		panic(errors.Wrap(err, "error while loading aws sqs config"))
 	}
@@ -114,6 +119,10 @@ func (c *Config) setDefaults() {
 
 	if c.RetryCount == 0 {
 		c.RetryCount = 3
+	}
+
+	if c.RequestTimeout <= 0 {
+		c.RequestTimeout = 5 * time.Second
 	}
 }
 
@@ -201,9 +210,6 @@ func (q *queue) sendBatchesConcurrently(batches [][]SQSMessageEntry) ([]SQSMessa
 // - err: An error indicating any failure during the concurrent deletion process, nil if all operations succeeded.
 func (q *queue) deleteBatchesConcurrently(batches [][]SQSDeleteMessageEntry) ([]SQSDeleteMessageEntry, error) {
 	failedEntries, err := doConcurrently(batches, q.workers, q.retryCount, q.deleteMessageBatch)
-	if err != nil {
-		return nil, err
-	}
 
 	return failedEntries, err
 }

--- a/inssqs/inssqs_test.go
+++ b/inssqs/inssqs_test.go
@@ -112,7 +112,7 @@ func TestQueue_DeleteMessageBatch(t *testing.T) {
 			{Id: aws.String("test-id")},
 		})
 
-		assert.Nil(t, err, "err should be nil")
+		assert.Error(t, err, "err should not be nil")
 		assert.NotNil(t, failed, "failed should not be nil")
 		assert.Equal(t, failed[0].Id, aws.String("test-id"), "failed id should be equal to test-id")
 	})
@@ -148,6 +148,7 @@ func TestQueue_getQueueUrl(t *testing.T) {
 
 		client.EXPECT().
 			GetQueueUrl(gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(3).
 			Return(nil, assert.AnError)
 
 		queueUrl, err := q.getQueueUrl()
@@ -186,6 +187,7 @@ func newQueue(t *testing.T) (queue, *sqs.MockAPI) {
 		client:     client,
 		name:       "test-queue",
 		retryCount: 3,
+		workers:    1,
 		logger:     inslogger.NewLogger(inslogger.Debug),
 	}, client
 }


### PR DESCRIPTION
## Why
pcd-change-sender Lambda hit ErrorsHigh 2026-08-04 08:53 UTC: one invocation finished all work in <1s then hung 29s in SQS DeleteMessageBatch until the 30s Lambda kill. aws-sdk-go-v2 default HTTP client has no timeout — a stalled connection hangs forever.

## Changes
- `Config.RequestTimeout` (default 5s) wired to the SDK HTTP client — bounds each request attempt; SDK adaptive retryer + existing app-level retry recover fast instead of hanging.
- `deleteBatchesConcurrently` no longer returns `nil` failed entries on error (callers lost which deletes failed; send path already returned them).
- Test suite repaired: helper deadlock (`workers: 0` blocked `doConcurrently` forever), delete test asserted no error on retry exhaustion (send counterpart asserts error), `GetQueueUrl` mock allowed 1 call but retry makes 3.

## Testing
`gofmt` clean, `go vet` clean, `go test ./...` green (suite hung indefinitely before).