### PR TITLE
fix(inssqs): data race, panic safety, and zero-worker deadlock in doConcurrently + lint CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,48 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  discover-modules:
+    name: Discover modules
+    runs-on:
+      labels: self-hosted
+    outputs:
+      modules: ${{ steps.discover.outputs.modules }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+      - name: Discover Go modules
+        id: discover
+        run: echo "modules=$(find . -name go.mod -not -path './.git/*' | xargs -n1 dirname | sort | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
+
+  golangci:
+    name: golangci-lint
+    needs: discover-modules
+    runs-on:
+      labels: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJson(needs.discover-modules.outputs.modules) }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.26.0
+          cache-dependency-path: ${{ matrix.module }}/go.sum
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+          working-directory: ${{ matrix.module }}
+          only-new-issues: true

--- a/inssqs/go.sum
+++ b/inssqs/go.sum
@@ -41,6 +41,10 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/useinsider/go-pkg/insdash v1.0.0 h1:hMHFDkuUAgua97KR0ok/NdqRRtJg0ZC3YBhXNPYi/OE=
+github.com/useinsider/go-pkg/insdash v1.0.0/go.mod h1:oZMiLIARsp470E9vknJARxkMqtp8jSsVmNMGcE4ie8c=
+github.com/useinsider/go-pkg/inslogger v1.0.0 h1:5xweYJj0s8TKeH+VZ4FOWm7nR56XDF8LrW71bt8YEes=
+github.com/useinsider/go-pkg/inslogger v1.0.0/go.mod h1:9qrRWJYNPS8QFRMvi7P4HT8lVQqWTY5V1hnvv/gxWiI=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/mock v0.3.0 h1:3mUxI1No2/60yUYax92Pt8eNOEecx2D3lcXZh2NEZJo=
 go.uber.org/mock v0.3.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=

--- a/inssqs/inssqs.go
+++ b/inssqs/inssqs.go
@@ -201,9 +201,6 @@ func (q *queue) sendBatchesConcurrently(batches [][]SQSMessageEntry) ([]SQSMessa
 // - err: An error indicating any failure during the concurrent deletion process, nil if all operations succeeded.
 func (q *queue) deleteBatchesConcurrently(batches [][]SQSDeleteMessageEntry) ([]SQSDeleteMessageEntry, error) {
 	failedEntries, err := doConcurrently(batches, q.workers, q.retryCount, q.deleteMessageBatch)
-	if err != nil {
-		return nil, err
-	}
 
 	return failedEntries, err
 }
@@ -386,10 +383,21 @@ func doConcurrently[T any](batches [][]T, workers int, retryCount int, f func([]
 		return nil, nil
 	}
 
+	if workers < 1 {
+		workers = 1
+	}
+
 	concurrentLimiter := make(chan struct{}, workers)
 	wg := sync.WaitGroup{}
+	var mu sync.Mutex
 	var outerErr error
 	failedEntriesChan := make(chan []T)
+
+	setErr := func(err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		outerErr = err
+	}
 
 	for _, batch := range batches {
 		wg.Add(1)
@@ -397,9 +405,15 @@ func doConcurrently[T any](batches [][]T, workers int, retryCount int, f func([]
 			defer wg.Done()
 			concurrentLimiter <- struct{}{}
 			defer func() { <-concurrentLimiter }()
+			defer func() {
+				if r := recover(); r != nil {
+					setErr(errors.Errorf("panic during concurrent batch operation: %v", r))
+					failedEntriesChan <- b
+				}
+			}()
 			fe, err := f(b, retryCount+1)
 			if err != nil {
-				outerErr = err
+				setErr(err)
 			}
 			failedEntriesChan <- fe
 		}(batch)

--- a/inssqs/inssqs_test.go
+++ b/inssqs/inssqs_test.go
@@ -1,6 +1,7 @@
 package inssqs
 
 import (
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
@@ -10,6 +11,7 @@ import (
 	"github.com/useinsider/go-pkg/inssqs/sqs"
 	"go.uber.org/mock/gomock"
 	"testing"
+	"time"
 )
 
 func TestQueue_SendMessageBatch(t *testing.T) {
@@ -112,7 +114,7 @@ func TestQueue_DeleteMessageBatch(t *testing.T) {
 			{Id: aws.String("test-id")},
 		})
 
-		assert.Nil(t, err, "err should be nil")
+		assert.NotNil(t, err, "err should not be nil")
 		assert.NotNil(t, failed, "failed should not be nil")
 		assert.Equal(t, failed[0].Id, aws.String("test-id"), "failed id should be equal to test-id")
 	})
@@ -148,6 +150,7 @@ func TestQueue_getQueueUrl(t *testing.T) {
 
 		client.EXPECT().
 			GetQueueUrl(gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(3).
 			Return(nil, assert.AnError)
 
 		queueUrl, err := q.getQueueUrl()
@@ -188,4 +191,59 @@ func newQueue(t *testing.T) (queue, *sqs.MockAPI) {
 		retryCount: 3,
 		logger:     inslogger.NewLogger(inslogger.Debug),
 	}, client
+}
+
+func Test_doConcurrently(t *testing.T) {
+	t.Run("should_not_race_when_multiple_workers_fail_concurrently", func(t *testing.T) {
+		batches := make([][]string, 16)
+		for i := range batches {
+			batches[i] = []string{"entry"}
+		}
+
+		failed, err := doConcurrently(batches, 8, 0, func(b []string, _ int) ([]string, error) {
+			time.Sleep(time.Millisecond)
+			return b, errors.New("send failed")
+		})
+
+		assert.NotNil(t, err, "err should not be nil")
+		assert.Len(t, failed, 16, "all entries should be reported as failed")
+	})
+
+	t.Run("should_recover_from_panic_and_mark_batch_failed", func(t *testing.T) {
+		batches := [][]string{{"panic-entry"}, {"ok-entry-1"}, {"ok-entry-2"}}
+
+		failed, err := doConcurrently(batches, 3, 0, func(b []string, _ int) ([]string, error) {
+			if b[0] == "panic-entry" {
+				panic("boom")
+			}
+
+			return nil, nil
+		})
+
+		assert.NotNil(t, err, "err should not be nil")
+		assert.Contains(t, err.Error(), "panic", "err should mention the panic")
+		assert.Equal(t, []string{"panic-entry"}, failed, "panicked batch should be reported as failed")
+	})
+
+	t.Run("should_not_deadlock_when_workers_is_zero", func(t *testing.T) {
+		batches := [][]string{{"a"}, {"b"}}
+
+		failed, err := doConcurrently(batches, 0, 0, func(_ []string, _ int) ([]string, error) {
+			return nil, nil
+		})
+
+		assert.Nil(t, err, "err should be nil")
+		assert.Empty(t, failed, "no entries should fail")
+	})
+
+	t.Run("should_return_no_error_when_all_batches_succeed", func(t *testing.T) {
+		batches := [][]string{{"a"}, {"b"}, {"c"}}
+
+		failed, err := doConcurrently(batches, 2, 0, func(_ []string, _ int) ([]string, error) {
+			return nil, nil
+		})
+
+		assert.Nil(t, err, "err should be nil")
+		assert.Empty(t, failed, "no entries should fail")
+	})
 }


### PR DESCRIPTION
#### Description
- While migrating pcd-change's hook enqueue to concurrent sending (PA-39898), we found that enabling inssqs's own MaxWorkers would activate three latent defects in the shared doConcurrently worker pool. This PR fixes them at the source so consumers can safely use MaxWorkers > 1, and adds a lint CI workflow.

#### Technical Description
- doConcurrently: outerErr was written by multiple goroutines without a lock (data race with MaxWorkers > 1); a panic inside a worker goroutine escaped and killed the process (no recover) — it is now recovered, the batch is reported failed, and the panic surfaces as an error; workers <= 0 made the concurrency limiter unbuffered and deadlocked every call — clamped to 1.
- deleteBatchesConcurrently returned nil failed entries on error, discarding the undelivered subset; aligned with the send variant and the documented contract.
- Test suite was effectively dead: every full run deadlocked on the first SendMessageBatch case (test helper builds a zero-valued queue → workers=0). With the deadlock gone, two never-executed tests had wrong expectations (delete-batch retry exhaustion, getQueueUrl retry count) — fixed to match actual semantics. New direct tests pin the race (fails under -race on develop), panic recovery, and zero-worker paths.
- New .github/workflows/lint.yml: discovers every Go module, runs golangci-lint v2.12.2 per module with only-new-issues so pre-existing findings do not block PRs.
- Verified: go vet clean; go test -race -count=3 green for the whole inssqs suite; golangci-lint on inssqs reports only one pre-existing finding (unused endpoint field, untouched).

#### Jira Task
 https://useinsider.atlassian.net/browse/PA-39898